### PR TITLE
Add limit number of MC files copied by copyAnaData

### DIFF
--- a/Core/scripts/copyAnaData.py
+++ b/Core/scripts/copyAnaData.py
@@ -225,7 +225,12 @@ def main():
     parser.add_option("-d", "--deleteBadFiles", action="store_true",  dest="remove")
     parser.add_option("-r", "--rootCheck", action="store_true",  dest="checkFilesWithRoot")
     parser.add_option("-s", "--srmls", action="store_true",  dest="usesrmls")
+    parser.add_option("-m", "--maxFilesMC", action="store",  type="int", dest="maxFilesMC")
     (options, args) = parser.parse_args()
+
+    maxFilesMC = -1
+    if options.maxFilesMC:
+        maxFilesMC = options.maxFilesMC
 
 
     if options.check:
@@ -296,6 +301,8 @@ def main():
             if not doCopy: continue
             cnt += 1
             targetFile = targetDir + "/" + fname
+            if not sampleList[s]["isData"] and maxFilesMC >= 0 and cnt >= maxFilesMC:
+                continue
 
 
             cpCommand = ['lcg-cp', srcFile, targetFile]


### PR DESCRIPTION
Dear Hans,

 among others this contains a small feature (commit  0e13b54) that allows to specify the number of MC files (per sample) to copy (data files are not affected). This will be usefull for the tutorial, so people can store the tutorial skim on ~9GB (75GB is the full skim)

Cheers,
 T
