### PR TITLE
Updates for 740 skim production

### DIFF
--- a/Core/plugins/CFFTreeProducer.cc
+++ b/Core/plugins/CFFTreeProducer.cc
@@ -1,0 +1,157 @@
+// -*- C++ -*-
+//
+// Package:    CFFTreeProducer
+// Class:      CFFTreeProducer
+// 
+/**\class CFFTreeProducer CFFTreeProducer.cc MNTriggerStudies/CFFTreeProducer/plugins/CFFTreeProducer.cc
+*/
+
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TTree.h"
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include <DataFormats/PatCandidates/interface/TriggerEvent.h>
+
+#include "CommonFSQFramework/Core/interface/EventIdData.h"
+#include "CommonFSQFramework/Core/interface/GenTrackView.h"
+#include "CommonFSQFramework/Core/interface/RecoTrackView.h"
+#include "CommonFSQFramework/Core/interface/VerticesView.h"
+
+//
+// class declaration
+//
+
+class CFFTreeProducer : public edm::EDAnalyzer {
+   public:
+      explicit CFFTreeProducer(const edm::ParameterSet&);
+      ~CFFTreeProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob();
+      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void endJob();
+
+      TTree *m_tree;
+      std::vector<EventViewBase *> m_views;
+
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+CFFTreeProducer::CFFTreeProducer(const edm::ParameterSet& iConfig)
+
+{
+    edm::Service<TFileService> tFileService;
+    m_tree = tFileService->make<TTree>("data", "data");
+    m_views.push_back(new EventIdData(iConfig.getParameter< edm::ParameterSet >("EventData"), m_tree));
+    m_views.push_back(new GenTrackView(iConfig.getParameter< edm::ParameterSet >("GenTrackView"), m_tree));
+    m_views.push_back(new RecoTrackView(iConfig.getParameter< edm::ParameterSet >("RecoTrackView"), m_tree));
+    m_views.push_back(new VerticesView(iConfig.getParameter< edm::ParameterSet >("VerticesView"), m_tree));
+}
+
+CFFTreeProducer::~CFFTreeProducer() {}
+
+void
+CFFTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+    using namespace edm;
+    for (unsigned int i = 0; i < m_views.size(); ++i){
+        m_views[i]->fill(iEvent, iSetup);
+    }
+    m_tree->Fill();
+
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+CFFTreeProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+CFFTreeProducer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void 
+CFFTreeProducer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void 
+CFFTreeProducer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void 
+CFFTreeProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void 
+CFFTreeProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+CFFTreeProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(CFFTreeProducer);

--- a/Core/python/JetViewsConfigs.py
+++ b/Core/python/JetViewsConfigs.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+def get(todo):
+    defs = {}
+    defs["JetViewPFAK4CHS"]  = cms.PSet(
+        miniView = cms.string("JetView"),
+        storeageVersion = cms.untracked.int32(1),
+        disableJetID = cms.bool(True),
+        optionalCaloJets4ID = cms.InputTag("ak5CaloJets","","RECO"),
+        optionalCaloID4ID  = cms.InputTag("ak5JetID"),
+        branchPrefix = cms.untracked.string("PFAK4CHS"),
+        maxEta = cms.double(5.2),
+        minPt = cms.double(3),
+        maxnum = cms.int32(3),
+        input = cms.InputTag("selectedPatJetsAK4PFCHSCopy"),
+        variations= cms.vstring("", "jecUp", "jecDown"),
+        jerFactors = cms.vstring(  # PF10
+                "5.5 1 0.007 0.07 0.072"),
+    )
+    # and so on
+    # defs["JetViewAK4Calo"]= cmsPSet(...
+
+    ret = {}
+    for t in todo:
+        if t not in defs:
+            raise Exception("miniView def not known "+t)
+
+        ret[t] = defs[t]
+    return ret
+
+

--- a/Core/python/customizePAT.py
+++ b/Core/python/customizePAT.py
@@ -94,13 +94,28 @@ def customize(process):
         process.XS.provHack = cms.string(stringForProv)
         process.TMFDataForProv = cms.PSet(notes = cms.string("test"))
 
-    # also - GT 
-
     #process.out.SelectEvents = cms.untracked.PSet(
     #        SelectEvents = selectorPaths
     #)
 
    
+    return process
+
+def customizeGT(process):
+    if not hasattr(process, "GlobalTag"):
+        raise Exception(("Process has no GT defined!"))
+
+    import os
+    if "TMFSampleName" not in os.environ:
+        print "Warning: input ds not known (TMFSampleName env not set). GlobalTag wont be customized"
+        return process
+
+    import CommonFSQFramework.Core.Util
+    sampleList=CommonFSQFramework.Core.Util.getAnaDefinition("sam")
+    s = os.environ["TMFSampleName"]
+
+    print "Setting globalTag to", sampleList[s]["GT"], "for sample",s
+    process.GlobalTag.globaltag = sampleList[s]["GT"]
     return process
 
 def removeEdmOutput(process):

--- a/Core/test/MNxsectionAna/do.py
+++ b/Core/test/MNxsectionAna/do.py
@@ -12,11 +12,11 @@ todoCat = ["InclusiveBasic", "InclusiveAsym", "InclusiveWindow", "MNBasic", "MNA
 #todoCat = ["InclusiveBasic"]
 todoSteps = []
 #todoSteps.append("proof")
-#todoSteps.append("simpleMCplots")
+todoSteps.append("simpleMCplots")
 #todoSteps.append("hadd")
 #todoSteps.append("draw")
-todoSteps.append("unfold")
-todoSteps.append("merge")
+#todoSteps.append("unfold")
+#todoSteps.append("merge")
 
 for cat in todoCat:
     for step in todoSteps:
@@ -42,7 +42,7 @@ for cat in todoCat:
             for t in todo:
                 os.system("./simpleMCplots.py -a {0},{1} -b {0},{2} -v {3}".format(t,samples[0], samples[1], cat))
                 #os.system("../simpleMCplots.py -d -a {0},{1} -b {0},{2} -v {3}".format(t,samples[0], samples[1], cat))
-            continue
+            #continue
             ptypes = ["fake" , "miss"]
             for ptype in ptypes:
                 for s in samples:

--- a/Core/test/MNxsectionAna/do.py
+++ b/Core/test/MNxsectionAna/do.py
@@ -3,23 +3,20 @@
 import os
 import fnmatch
 
-
-
 #todoSteps = ["proof", "hadd", "draw", "unfold", "merge"]
-#todoCat = ["InclusiveBasic", "InclusiveAsym", "InclusiveWindow", "MNBasic", "MNAsym", "MNWindow"]
-#todoCat = ["InclusiveWindow", "InclusiveAsym", "InclusiveBasic", "MNBasic", "MNAsym", "MNWindow", "FWD11_002"]
+todoCat = ["InclusiveBasic", "InclusiveAsym", "InclusiveWindow", "MNBasic", "MNAsym", "MNWindow"]
 #todoCat = ["InclusiveBasic"]
-todoCat = ["MNAsym"]
+#todoCat = ["MNAsym"]
 #todoCat = ["MNWindow"]
 #todoCat = ["FWD11_002"]
 #todoCat = ["InclusiveBasic"]
 todoSteps = []
 #todoSteps.append("proof")
-todoSteps.append("simpleMCplots")
+#todoSteps.append("simpleMCplots")
 #todoSteps.append("hadd")
 #todoSteps.append("draw")
-#todoSteps.append("unfold")
-#todoSteps.append("merge")
+todoSteps.append("unfold")
+todoSteps.append("merge")
 
 for cat in todoCat:
     for step in todoSteps:

--- a/Core/test/MNxsectionAna/simpleMCplots.py
+++ b/Core/test/MNxsectionAna/simpleMCplots.py
@@ -119,6 +119,17 @@ def main():
             if "ptHat" == nameH:
                 xLab = "#hat{p}_{T}"
                 yLab = "events [a.u.]"
+            elif "miss" in nameH:
+                xLab = "#Delta #eta"
+                yLab = "p_{miss}"
+                toPlot[h].SetMinimum(0)
+                toPlot[h].SetMaximum(1)
+            elif "fake" in nameH:
+                xLab = "#Delta #eta"
+                yLab = "p_{fake}"
+                toPlot[h].SetMinimum(0)
+                toPlot[h].SetMaximum(1)
+
 
             toPlot[h].GetXaxis().SetTitle(xLab)
             toPlot[h].GetYaxis().SetTitle(yLab)

--- a/Core/test/MNxsectionAna/unfoldMN.py
+++ b/Core/test/MNxsectionAna/unfoldMN.py
@@ -99,6 +99,7 @@ def doUnfold(measured, rooresponse, nIter = None):
     unfold = ROOT.RooUnfoldBayes(rooresponse, measured, nIter)
 
     errorTreatment = 1 
+    #errorTreatment = 3
     hReco= unfold.Hreco(errorTreatment)
 
     chi2 = unfold.Chi2(rooresponse.Htruth(),errorTreatment)
@@ -127,6 +128,27 @@ def scale2d(h, s):
             h.SetBinError(i, j, err)
 
 
+# this returns a tuple of three histograms
+#   central histo (with errors set to 0)
+#   +- err histos
+def extractErrors(h):
+    ret = h.Clone()
+    retUp = h.Clone()
+    retDown = h.Clone()
+    map(lambda h: h.Reset(), [ret, retUp, retDown])
+    map(lambda h: h.Sumw2(), [ret, retUp, retDown])
+
+    for i in xrange(0, h.GetNbinsX()+2):
+        val = h.GetBinContent(i)
+        err = h.GetBinError(i)
+        ret.SetBinContent(i, val)
+        ret.SetBinError(i, 0)
+        retUp.SetBinContent(i, val+err)
+        retUp.SetBinError(i, 0)
+        retDown.SetBinContent(i, val-err)
+        retDown.SetBinError(i, 0)
+
+    return (ret, retUp, retDown)
 
 def getPossibleActions():
     return set(["pythiaOnData", "herwigOnData", "pythiaOnHerwig", "herwigOnPythia", "herwigOnHerwig", "pythiaOnPythia"])
@@ -228,9 +250,32 @@ def unfold(action, infileName):
             sys.stdout.flush()
 
             hReco = doUnfold(histo.Clone(), histos[baseMC][r].Clone())[0] # chi2 is on second part of ntuple
-            hReco.SetName(rawName)
-            odirROOTfile.WriteTObject(hReco, rawName)
+            # unfolding sets the errors of the unfolded histo to the ones from 
+            # covariance matrix (ie this do not correspond to  stat errors from input distribution)
+            #  so we treat those as just another variation
+            # note: disabled
+            if "central" in variation and False:
+                hAndErr=extractErrors(hReco)
+                centralValueWithoutErrors = hAndErr[0]
+                up   = hAndErr[1]
+                down = hAndErr[2]
+                centralValueWithoutErrors.SetName(rawName)
+                centralValueWithoutErrorsRawName = rawName
+                # if toyMC was disabled write without errors
+                # if toyMC is enabled stat errors will be fetched from toyMC variations named "measured"
+                if optionsReg["disableToys"]:
+                    odirROOTfile.WriteTObject(centralValueWithoutErrors, centralValueWithoutErrorsRawName)
+                upName = rawName.replace("central", "unfcovUp")
+                downName = rawName.replace("central", "unfcovDown")
+                up.SetName(upName)
+                odirROOTfile.WriteTObject(up,upName)
+                down.SetName(downName)
+                odirROOTfile.WriteTObject(down,downName)
+            else:
+                hReco.SetName(rawName)
+                odirROOTfile.WriteTObject(hReco, rawName)
 
+            # perform chi2 vs nIter scan (doesnt affect the final result
             if "central" in variation:
                 scanName = "chi2scan_"+rawName
                 hScan = ROOT.TH1F(scanName, scanName+";iterations;chi^{2}", 8, 0.5, 8.5)
@@ -242,10 +287,11 @@ def unfold(action, infileName):
                 canv = ROOT.TCanvas()
                 canv.SetLeftMargin(0.2)
                 hScan.Draw()
-                canv.Print(optionsReg["odir"]+"/{}_{}.png".format(action,scanName))
-                canv.Print(optionsReg["odir"]+"/{}_{}.pdf".format(action,scanName))
+                canv.Print(optionsReg["odir"]+"/chi2/{}_{}.png".format(action,scanName))
+                canv.Print(optionsReg["odir"]+"/chi2/{}_{}.pdf".format(action,scanName))
 
             # now - toyMC approac to limited MC statistics
+            #todo = ["response", "fakes", "truth", "measured"]
             todo = ["response", "fakes", "truth"]
             #todo = ["truth"]
             if optionsReg["disableToys"]:
@@ -262,6 +308,8 @@ def unfold(action, infileName):
                         hfakes = clonedResponse.Hfakes()
                         hresponse = clonedResponse.Hresponse()
                         hmeas = clonedResponse.Hmeasured()
+
+                        histoToUnfold = histo.Clone()
                         if t == "truth":
                             vary(htruth)
                         elif t == "fakes":
@@ -272,12 +320,15 @@ def unfold(action, infileName):
                             hmeas.Add(fakesDiff)
                         elif t == "response":
                             vary(hresponse)
+                        elif t == "measured":
+                            vary(histoToUnfold)
+
                         else:
                             raise Exception("dont know what to do")
 
                         newResponse = ROOT.RooUnfoldResponse(hmeas, htruth, hresponse, \
                                                              "resp_{}_{}_{}".format(rawName, t,i)) 
-                        hRecoVaried = doUnfold(histo.Clone(), newResponse)[0]
+                        hRecoVaried = doUnfold(histoToUnfold, newResponse)[0]
                         #print "TTT", hReco.Integral(), hRecoVaried.Integral()
                         binv1 =  hRecoVaried.GetBinContent(1)
                         if math.isnan(binv1) or math.isinf(binv1): 
@@ -309,8 +360,22 @@ def unfold(action, infileName):
                         print "binc: {} {}, vals ratio {}, error: {}".format(binc1, binc2, val1/val2, errProf/val1)
                         hUp.SetBinContent(i, val1+errProf)
                         hDown.SetBinContent(i, val1-errProf)
-                    odirROOTfile.WriteTObject(hUp, rawNameUp)
-                    odirROOTfile.WriteTObject(hDown, rawNameDown)
+
+                    if t != "measured":
+                        odirROOTfile.WriteTObject(hUp, rawNameUp)
+                        odirROOTfile.WriteTObject(hDown, rawNameDown)
+                    else:
+                        for i in xrange(0, centralValueWithoutErrors.GetNbinsX()+1):
+                            valCen = centralValueWithoutErrors.GetBinContent(i)
+                            valUp  = hUp.GetBinContent(i)
+                            valDown  = hDown.GetBinContent(i)
+                            err1 = abs(valCen-valUp)
+                            err2 = abs(valCen-valDown)
+                            err = (err1+err2)/2.
+                            if valCen > 0:
+                                print "Stat errors from toy:", err, valCen, err/valCen
+                            centralValueWithoutErrors.SetBinError(i,err)
+                        odirROOTfile.WriteTObject(centralValueWithoutErrors, centralValueWithoutErrorsRawName)
                     print "TOYmc done for", r, " bad toys:", badToys
 
                     #ccc = hReco.Clone()
@@ -361,6 +426,7 @@ def compareMCGentoMCUnfolded(action, infileName):
         genHisto.SetMaximum(trueMax*1.07)
 
         c.Print(optionsReg["odir"]+"/MConMCunfoldingTest_"+action+t+".png")
+        c.Print(optionsReg["odir"]+"/MConMCunfoldingTest_"+action+t+".pdf")
 
 def main():
     CommonFSQFramework.Core.Style.setTDRStyle()
@@ -369,6 +435,7 @@ def main():
     optionsReg["ntoys"]  = 1000
     optionsReg["unfNIter"]  = 3
     optionsReg["disableToys"]  = False
+    #optionsReg["disableToys"]  = True
     
     parser = OptionParser(usage="usage: %prog [options] filename",
                             version="%prog 1.0")
@@ -386,6 +453,7 @@ def main():
     infileName = "plotsMNxs_{}.root".format(options.variant)
     odir = "~/tmp/unfolded_{}/".format(options.variant)
     os.system("mkdir -p "+odir)
+    os.system("mkdir -p "+odir+"/chi2")
     optionsReg["odir"] = odir
 
     #possibleActions = ["pythiaOnPythia",  "herwigOnPythia", "pythiaOnHerwig", "herwigOnHerwig"]
@@ -394,5 +462,6 @@ def main():
         compareMCGentoMCUnfolded(action, infileName)
 
 if __name__ == "__main__":
+    # note http://indico.cern.ch/event/107747/session/1/material/slides/1?contribId=72, s.19
     main()
 

--- a/Core/test/MNxsectionAna/unfoldMN.py
+++ b/Core/test/MNxsectionAna/unfoldMN.py
@@ -248,8 +248,16 @@ def unfold(action, infileName):
             print "Doing: ", c, r, variation
             rawName = "xsunfolded_" + variation+ c
             sys.stdout.flush()
-
+        
+            '''
+            histoWithChangedErrors = histo.Clone()
+            for i in xrange(histoWithChangedErrors.GetNbinsX()+2):
+                err = histoWithChangedErrors.GetBinError(i)
+                histoWithChangedErrors.SetBinError(i, err/2)
+            hReco = doUnfold(histoWithChangedErrors, histos[baseMC][r].Clone())[0] # chi2 is on second part of ntuple
+            '''
             hReco = doUnfold(histo.Clone(), histos[baseMC][r].Clone())[0] # chi2 is on second part of ntuple
+            # '''
             # unfolding sets the errors of the unfolded histo to the ones from 
             # covariance matrix (ie this do not correspond to  stat errors from input distribution)
             #  so we treat those as just another variation

--- a/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
+++ b/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
@@ -118,7 +118,28 @@ process.out.fileName = 'patTuple_addJets.root'
 import CommonFSQFramework.Core.customizePAT
 process = CommonFSQFramework.Core.customizePAT.customize(process)
 
+process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
+    JetViewPFAK4CHS  = cms.PSet(
+        miniView = cms.string("JetView"),
+        disableJetID = cms.bool(True),
+        optionalCaloJets4ID = cms.InputTag("ak5CaloJets","","RECO"),
+        optionalCaloID4ID  = cms.InputTag("ak5JetID"),
+        branchPrefix = cms.untracked.string("PFAK4CHS"),
+        maxEta = cms.double(5.2),
+        minPt = cms.double(3),
+        maxnum = cms.int32(3),
+        input = cms.InputTag("selectedPatJetsAK4PFCHSCopy"),
+        variations= cms.vstring("", "jecUp", "jecDown"),
+        jerFactors = cms.vstring(  # PF10
+                "5.5 1 0.007 0.07 0.072"),
+    )
+)
 
 
+process = CommonFSQFramework.Core.customizePAT.addTreeProducer(process, process.JetTree)
+
+
+
+process.source.fileNames = cms.untracked.vstring("file:44E1E4BA-50BD-E411-A57A-002618943949.root" )
 
 

--- a/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
+++ b/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
@@ -114,6 +114,9 @@ process.out.fileName = 'patTuple_addJets.root'
 import CommonFSQFramework.Core.customizePAT
 process = CommonFSQFramework.Core.customizePAT.customize(process)
 
+# GT customization
+process = CommonFSQFramework.Core.customizePAT.customizeGT(process)
+
 process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
     JetViewPFAK4CHS  = cms.PSet(
         miniView = cms.string("JetView"),

--- a/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
+++ b/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
@@ -107,20 +107,17 @@ process.maxEvents.input = 10
 process.out.fileName = 'patTuple_addJets.root'
 #                                         ##
 #   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)
-
-
-
+#process.source.fileNames = cms.untracked.vstring("file:44E1E4BA-50BD-E411-A57A-002618943949.root" )
 
 
 # Here starts the CFF specific part
-
-
 import CommonFSQFramework.Core.customizePAT
 process = CommonFSQFramework.Core.customizePAT.customize(process)
 
 process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
     JetViewPFAK4CHS  = cms.PSet(
         miniView = cms.string("JetView"),
+        storeageVersion = cms.untracked.int32(1),
         disableJetID = cms.bool(True),
         optionalCaloJets4ID = cms.InputTag("ak5CaloJets","","RECO"),
         optionalCaloID4ID  = cms.InputTag("ak5JetID"),
@@ -132,14 +129,10 @@ process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
         variations= cms.vstring("", "jecUp", "jecDown"),
         jerFactors = cms.vstring(  # PF10
                 "5.5 1 0.007 0.07 0.072"),
+
     )
 )
 
-
 process = CommonFSQFramework.Core.customizePAT.addTreeProducer(process, process.JetTree)
-
-
-
-process.source.fileNames = cms.untracked.vstring("file:44E1E4BA-50BD-E411-A57A-002618943949.root" )
 
 

--- a/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
+++ b/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
@@ -117,25 +117,22 @@ process = CommonFSQFramework.Core.customizePAT.customize(process)
 # GT customization
 process = CommonFSQFramework.Core.customizePAT.customizeGT(process)
 
-process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
-    JetViewPFAK4CHS  = cms.PSet(
-        miniView = cms.string("JetView"),
-        storeageVersion = cms.untracked.int32(1),
-        disableJetID = cms.bool(True),
-        optionalCaloJets4ID = cms.InputTag("ak5CaloJets","","RECO"),
-        optionalCaloID4ID  = cms.InputTag("ak5JetID"),
-        branchPrefix = cms.untracked.string("PFAK4CHS"),
-        maxEta = cms.double(5.2),
-        minPt = cms.double(3),
-        maxnum = cms.int32(3),
-        input = cms.InputTag("selectedPatJetsAK4PFCHSCopy"),
-        variations= cms.vstring("", "jecUp", "jecDown"),
-        jerFactors = cms.vstring(  # PF10
-                "5.5 1 0.007 0.07 0.072"),
-
-    )
-)
-
+process.JetTree = cms.EDAnalyzer("CFFTreeProducer")
+import CommonFSQFramework.Core.JetViewsConfigs
+process.JetTree._Parameterizable__setParameters(CommonFSQFramework.Core.JetViewsConfigs.get(["JetViewPFAK4CHS"]))
 process = CommonFSQFramework.Core.customizePAT.addTreeProducer(process, process.JetTree)
+
+# PAT customization for data
+import os
+if "TMFSampleName" not in os.environ:
+    print "TMFSampleName not found, assuming we are running on MC"
+else:
+    s = os.environ["TMFSampleName"]
+    sampleList=CommonFSQFramework.Core.Util.getAnaDefinition("sam")
+    isData =  sampleList[s]["isData"]
+    if isData:
+        print "Disabling MC-specific features for sample",s
+        runOnData(process)    
+        removeMCMatching(process, ['All'])  
 
 

--- a/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
+++ b/Core/test/SkimConfigurations/Jets/S0_makePAT_74.py
@@ -1,0 +1,124 @@
+## import skeleton process
+from PhysicsTools.PatAlgos.patTemplate_cfg import *
+## switch to uncheduled mode
+process.options.allowUnscheduled = cms.untracked.bool(True)
+#process.Tracer = cms.Service("Tracer")
+
+process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
+
+from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+#addMETCollection(process, labelName='patMETCalo', metSource='met')
+addMETCollection(process, labelName='patMETPF', metSource='pfMetT1')
+#addMETCollection(process, labelName='patMETTC', metSource='tcMet') # FIXME: removed from RECO/AOD; needs functionality to add to processing
+
+## uncomment the following line to add different jet collections
+## to the event content
+from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
+from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
+
+## uncomment the following lines to add ak4PFJetsCHS to your PAT output
+labelAK4PFCHS = 'AK4PFCHS'
+postfixAK4PFCHS = 'Copy'
+addJetCollection(
+   process,
+   postfix   = postfixAK4PFCHS,
+   labelName = labelAK4PFCHS,
+   jetSource = cms.InputTag('ak4PFJetsCHS'),
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2')
+   )
+process.out.outputCommands.append( 'drop *_selectedPatJets%s%s_caloTowers_*'%( labelAK4PFCHS, postfixAK4PFCHS ) )
+
+# uncomment the following lines to add ak4PFJets to your PAT output
+switchJetCollection(
+   process,
+   jetSource = cms.InputTag('ak4PFJets'),
+   jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'),
+   btagDiscriminators = [
+       'pfJetBProbabilityBJetTags'
+     , 'pfJetProbabilityBJetTags'
+     , 'pfTrackCountingHighPurBJetTags'
+     , 'pfTrackCountingHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighPurBJetTags'
+     , 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
+     ]
+   )
+process.out.outputCommands.append( 'drop *_selectedPatJets_caloTowers_*' )
+
+# uncomment the following lines to add ak8PFJetsCHSSoftDrop to your PAT output
+labelAK8PFCHSSoftDrop = 'AK8PFCHSSoftDrop'
+addJetCollection(
+   process,
+   labelName = labelAK8PFCHSSoftDrop,
+   jetSource = cms.InputTag('ak8PFJetsCHSSoftDrop',''),
+   algo = 'AK',
+   rParam = 0.8,
+   genJetCollection = cms.InputTag('ak8GenJets'),
+   jetCorrections = ('AK8PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+   btagDiscriminators = ['None'], # turn-off b tagging
+   getJetMCFlavour = False # jet flavor needs to be disabled for groomed fat jets
+   )
+process.out.outputCommands.append( 'keep *_selectedPatJets%s_pfCandidates_*'%( labelAK8PFCHSSoftDrop ) )
+process.out.outputCommands.append( 'drop *_selectedPatJets%s_caloTowers_*'%( labelAK8PFCHSSoftDrop ) )
+
+# uncomment the following lines to switch to ak4CaloJets in your PAT output
+labelAK4Calo = 'AK4Calo'
+addJetCollection(
+   process,
+   labelName = labelAK4Calo,
+   jetSource = cms.InputTag('ak4CaloJets'),
+   jetCorrections = ('AK7Calo', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'), # FIXME: Use proper JECs, as soon as available
+   btagDiscriminators = [
+       'pfJetBProbabilityBJetTags'
+     , 'pfJetProbabilityBJetTags'
+     , 'pfTrackCountingHighPurBJetTags'
+     , 'pfTrackCountingHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighPurBJetTags'
+     , 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
+     ]
+   )
+process.out.outputCommands.append( 'drop *_selectedPatJets%s_pfCandidates_*'%( labelAK4Calo ) )
+## JetID works only with RECO input for the CaloTowers (s. below for 'process.source.fileNames')
+#process.patJets.addJetID=True
+#process.load("RecoJets.JetProducers.ak4JetID_cfi")
+#process.patJets.jetIDMap="ak4JetID"
+process.patJetsAK4Calo.useLegacyJetMCFlavour=True # Need to use legacy flavour since the new flavour requires jet constituents which are dropped for CaloJets from AOD
+
+#print process.out.outputCommands
+
+## ------------------------------------------------------
+#  In addition you usually want to change the following
+#  parameters:
+## ------------------------------------------------------
+#
+#   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
+#                                         ##
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
+process.source.fileNames = filesRelValProdTTbarAODSIM
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarGENSIMRECO
+#process.source.fileNames = filesRelValProdTTbarGENSIMRECO
+#                                         ##
+process.maxEvents.input = 10
+#                                         ##
+#   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
+#                                         ##
+process.out.fileName = 'patTuple_addJets.root'
+#                                         ##
+#   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)
+
+
+
+
+
+# Here starts the CFF specific part
+
+
+import CommonFSQFramework.Core.customizePAT
+process = CommonFSQFramework.Core.customizePAT.customize(process)
+
+
+
+
+

--- a/Core/test/SkimConfigurations/readme.txt
+++ b/Core/test/SkimConfigurations/readme.txt
@@ -41,7 +41,44 @@ removing the output most likely will prevent large number of CMSSW modules
 from running thanks to magic of unscheduled execution)
 
 
-3. Add plugins
+3. Add tree producers
+
+A tree producer in CFF is a edm plugin calling several miniViews (see src
+directory) in order to fill a tree. Since April 2015 there is no need to
+compose a tree producer from miniviews by hand. For most uses a generic tree
+producer named CFFTreeProducer should be enough. In configuration you need to
+provide from 0 to several psets with miniviews configuration. Each pset must
+contain miniView type and branch prefix (branches produced by this producer
+will start from this string). 
+
+
+process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
+    JetViewPFAK4CHS  = cms.PSet(
+        miniView = cms.string("JetView"),
+        branchPrefix = cms.untracked.string("PFAK4CHS"),
+        (...) # here follows rest of configuration, e.g. inputtags
+    ),
+    JetViewCaloAK  = cms.PSet(
+        miniView = cms.string("JetView"),
+        branchPrefix = cms.untracked.string("CaloAK4"),
+        (...)
+    ),
+
+    (...) # other miniviews
+)
+
+See CFFTreeProducer source code (plugins directory) in order to learn what
+miniviews are supported
+
+Last thing to do is to make sure our tree producer will be executed. This is
+done by another customization function:
+
+process = CommonFSQFramework.Core.customizePAT.addTreeProducer(process, process.JetTree)
+
+4.  TODO: describe GT modifications (different GT for data/MC)
+
+
+
 
 
 

--- a/Core/test/SkimConfigurations/readme.txt
+++ b/Core/test/SkimConfigurations/readme.txt
@@ -75,7 +75,16 @@ done by another customization function:
 
 process = CommonFSQFramework.Core.customizePAT.addTreeProducer(process, process.JetTree)
 
-4.  TODO: describe GT modifications (different GT for data/MC)
+4. Global tag modifications 
+
+  runCrabJobs.py scripts are able to communicate with the python configuration
+via shell environment variables. Variable TMFSampleName contains a name of a
+sample for which crab jobs are created. Following customization call
+
+process = CommonFSQFramework.Core.customizePAT.customizeGT(process)
+
+tries to read TMFSampleName variable from environment and set the global
+tag to the one from samplesDictionary[TMFSampleName]["GT"] variable
 
 
 

--- a/Core/test/SkimConfigurations/readme.txt
+++ b/Core/test/SkimConfigurations/readme.txt
@@ -1,0 +1,54 @@
+This file describes process of new skim creation. Most importantly it explains how to attach 
+services of the CFF to the existing python configuration.
+
+For jet based analyses (ie the jet skim) we want to use basic PAT
+configuration, since it merges all the scaterred information into a single
+object (pat::Jet). It also takes care of applying JEC.
+
+Note: for different analysis (e.g. track based) we could start with a 
+basic configuration file with only source/geometry/gt/... definitions. There
+is nothing that forces us to use PAT if we dont need it.
+
+1. Create python config
+
+ Configuration with different jet collections processed by PAT is avaliable in
+
+PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+
+ This file was copied and saved as S0_makePAT_74.py
+
+
+2. Add basic CFF services
+
+at the end of the file append
+------
+import CommonFSQFramework.Core.customizePAT
+process = CommonFSQFramework.Core.customizePAT.customize(process)
+------
+note: it should also work on regular, ie non-PAT, configurations. If not -
+contact CFF developers
+
+Above customization peforms the following
+- Add CFF event counters
+- Add TFileService
+- Remove the edm output module if present in configuration 
+(may need fixing, if it doesnt work contact CFF  developers)
+
+Since event data is saved in our trees it makes no sense to produce a standard
+edm output (we dont use it in the framework). Keeping the edm output in
+configuration will make your crab jobs to run significantly longer (note:
+removing the output most likely will prevent large number of CMSSW modules
+from running thanks to magic of unscheduled execution)
+
+
+3. Add plugins
+
+
+
+
+
+
+
+
+
+

--- a/Core/test/SkimConfigurations/readme.txt
+++ b/Core/test/SkimConfigurations/readme.txt
@@ -16,7 +16,7 @@ is nothing that forces us to use PAT if we dont need it.
 PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
 
  This file was copied and saved as S0_makePAT_74.py
-
+(CommonFSQFramework/Core/test/SkimConfigurations/Jets directory)
 
 2. Add basic CFF services
 
@@ -67,13 +67,34 @@ process.JetTree = cms.EDAnalyzer("CFFTreeProducer",
     (...) # other miniviews
 )
 
-See CFFTreeProducer source code (plugins directory) in order to learn what
-miniviews are supported
+See CFFTreeProducer source code (plugins directory) to learn what
+miniviews are supported. Please contact us if you want your miniview to be
+included
 
 Last thing to do is to make sure our tree producer will be executed. This is
 done by another customization function:
 
 process = CommonFSQFramework.Core.customizePAT.addTreeProducer(process, process.JetTree)
+
+3b) Preffered way to configure tree producer
+
+A different way to configure the CFFTreeProducer is to first create it without
+any miniviews:
+
+--------------
+process.JetTree = cms.EDAnalyzer("CFFTreeProducer")
+--------------
+
+and than to fetch and "attach" to it miniViews configuration from python
+directory:
+
+----------------
+import CommonFSQFramework.Core.JetViewsConfigs
+process.JetTree._Parameterizable__setParameters(CommonFSQFramework.Core.JetViewsConfigs.get(["JetViewPFAK4CHS"]))
+----------------
+ 
+The "get" method expects a list of configuration names. This way a centralized 
+miniviews configuration is avaliable to all skim configurations.
 
 4. Global tag modifications 
 
@@ -87,6 +108,24 @@ tries to read TMFSampleName variable from environment and set the global
 tag to the one from samplesDictionary[TMFSampleName]["GT"] variable
 
 
+5. data/MC customization
+
+ Sometims it is necessary to apply some specific configuration changes when
+running on data/MC. This again can be done using "TMFSampleName" env variable
+
+----------------------------
+import os
+if "TMFSampleName" not in os.environ:
+    print "TMFSampleName not found, assuming we are running on MC"
+else:
+    s = os.environ["TMFSampleName"]
+    sampleList=CommonFSQFramework.Core.Util.getAnaDefinition("sam")
+    isData =  sampleList[s]["isData"]
+    if isData:
+        print "Disabling MC-specific features for sample",s
+        runOnData(process)    
+        removeMCMatching(process, ['All'])  
+-----------------
 
 
 


### PR DESCRIPTION
Dear Hans,

  this contains working 740 configuration for jet tree production. 
1. Note new, shiny and universal CFFTreePlugin
   - here it would be nice to have event filtering possibility, maybe using some similar "plugin" mechanism to miniViews (miniFilters?). To avoid code duplication they should probably operate on results of miniviews (before calling the filter method), I'm not sure if this is easily doable
2. Lets have a central directory for different skims: CommonFSQFramework/Core/test/SkimConfigurations/
   - note the readme.txt file in there describing the config creation process
3. Jets  directory contains first working config for jet tree. 

Would  you be able to create a new Template file for 2015 jet trees production and test it? We could try with some 740 relvals or 720 (PHYS14) highPU MC  (e.q. flat pt QCD and NeutrinoGun to simulate the data)

 cheers,
   Tomasz
