### PR TITLE
Add Castor MiniViews

### DIFF
--- a/Core/interface/CastorJetView.h
+++ b/Core/interface/CastorJetView.h
@@ -1,0 +1,18 @@
+#ifndef CastorJetView_h
+#define CastorJetView_h
+
+#include "CommonFSQFramework/Core/interface/EventViewBase.h"
+#include "DataFormats/CastorReco/interface/CastorTower.h"
+#include "DataFormats/JetReco/interface/BasicJet.h"
+
+class CastorJetView: public EventViewBase {
+    public:
+       CastorJetView(const edm::ParameterSet& ps, TTree * tree);
+
+    private:
+      virtual void fillSpecific(const edm::Event&, const edm::EventSetup&);  
+      double m_minCastorJetEnergy;
+      double m_jetRadius;
+};
+
+#endif

--- a/Core/interface/CastorRecHitView.h
+++ b/Core/interface/CastorRecHitView.h
@@ -1,0 +1,14 @@
+#ifndef CastorRecHitView_h
+#define CastorRecHitView_h
+
+#include "CommonFSQFramework/Core/interface/EventViewBase.h"
+
+class CastorRecHitView: public EventViewBase {
+    public:
+       CastorRecHitView(const edm::ParameterSet& ps, TTree * tree);
+
+    private:
+      virtual void fillSpecific(const edm::Event&, const edm::EventSetup&);  
+};
+
+#endif

--- a/Core/plugins/CFFTreeProducer.cc
+++ b/Core/plugins/CFFTreeProducer.cc
@@ -32,6 +32,8 @@
 #include "CommonFSQFramework/Core/interface/GenJetView.h"
 #include "CommonFSQFramework/Core/interface/RecoTrackView.h"
 #include "CommonFSQFramework/Core/interface/VerticesView.h"
+#include "CommonFSQFramework/Core/interface/CastorRecHitView.h"
+#include "CommonFSQFramework/Core/interface/CastorJetView.h"
 
 #include "CommonFSQFramework/Core/interface/JetView.h"
 #include "CommonFSQFramework/Core/interface/TriggerResultsView.h"
@@ -131,6 +133,12 @@ CFFTreeProducer::CFFTreeProducer(const edm::ParameterSet& iConfig)
         }
         else if (miniViewType == "VerticesView") {
             m_views.push_back(new VerticesView(pset, m_tree));
+        }
+        else if (miniViewType == "CastorRecHitView") {
+            m_views.push_back(new CastorRecHitView(pset, m_tree));
+        }
+        else if (miniViewType == "CastorJetView") {
+            m_views.push_back(new CastorJetView(pset, m_tree));
         }
         else {
             throw "Miniview not known: "+ miniViewType;

--- a/Core/python/CastorViewsConfigs.py
+++ b/Core/python/CastorViewsConfigs.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+def get(todo):
+    defs = {}
+    defs["ak5GenJetView"]= cms.PSet(   
+        miniView = cms.string("GenJetView"),
+        branchPrefix = cms.untracked.string("ak5GenJets"),
+        maxEta = cms.double(7.0),
+        minPt = cms.double(1.0),
+        genJets = cms.InputTag("ak5GenJets"),
+    )
+
+    defs["ak5CastorJetView"]= cms.PSet(   
+        miniView = cms.string("CastorJetView"),
+        branchPrefix = cms.untracked.string("ak5CastorJets"),
+        minCastorJetEnergy = cms.double(50.),
+        jetRadius = cms.double(0.5)
+    )
+
+    defs["ak7CastorJetView"]= cms.PSet(   
+        miniView = cms.string("CastorJetView"),
+        branchPrefix = cms.untracked.string("ak7CastorJets"),
+        minCastorJetEnergy = cms.double(50.),
+        jetRadius = cms.double(0.7)
+    )
+
+    defs["VerticesView"]= cms.PSet(   
+        miniView = cms.string("VerticesView"),
+        branchPrefix = cms.untracked.string("Vtx"),
+        src = cms.InputTag("offlinePrimaryVertices"),
+    )
+
+    defs["CastorRecHitView"]= cms.PSet(   
+        miniView = cms.string("CastorRecHitView"),
+        branchPrefix = cms.untracked.string("CastorRecHit"),
+    )   
+
+    defs["JetViewPFAK4CHS"]  = cms.PSet(
+        miniView = cms.string("JetView"),
+        storeageVersion = cms.untracked.int32(0),
+        disableJetID = cms.bool(True),
+        optionalCaloJets4ID = cms.InputTag(""),#ak5CaloJets","","RECO"),
+        optionalCaloID4ID  = cms.InputTag(""),#ak5JetID"),
+        branchPrefix = cms.untracked.string("PFAK4CHS"),
+        maxEta = cms.double(5.2),
+        minPt = cms.double(1),
+        maxnum = cms.int32(3),
+        input = cms.InputTag("selectedPatJetsAK4PFCHSCopy"),
+        variations= cms.vstring(""),
+        jerFactors = cms.vstring(  # PF10
+                "5.5 1 0.007 0.07 0.072"),
+    )
+
+    ret = {}
+    for t in todo:
+        if t not in defs:
+            raise Exception("miniView def not known "+t)
+
+        ret[t] = defs[t]
+    return ret
+
+

--- a/Core/src/BuildFile.xml
+++ b/Core/src/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/PatCandidates"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="CondFormats/JetMETObjects"/>
+<use name="DataFormats/HcalRecHit"/>
 <export>
    <lib name="1"/>
 </export>

--- a/Core/src/CastorJetView.cc
+++ b/Core/src/CastorJetView.cc
@@ -1,0 +1,51 @@
+#include "CommonFSQFramework/Core/interface/CastorJetView.h"
+#include "DataFormats/JetReco/interface/BasicJet.h"
+#include "DataFormats/JetReco/interface/CastorJetID.h"
+#include <sstream>
+
+
+CastorJetView::CastorJetView(const edm::ParameterSet& iConfig, TTree * tree):
+EventViewBase(iConfig,  tree)
+{
+    registerVecP4("P4", tree);
+    registerVecInt("nTowers", tree);
+    registerVecFloat("fem", tree);
+    registerVecFloat("width", tree);
+    registerVecFloat("depth", tree);
+
+    // fetch config data
+    m_minCastorJetEnergy = iConfig.getParameter<double>("minCastorJetEnergy");
+    m_jetRadius = iConfig.getParameter<double>("jetRadius");
+}
+
+
+void CastorJetView::fillSpecific(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+
+   edm::Handle<edm::View<reco::BasicJet> > jetsIn;
+   edm::Handle<reco::CastorJetIDValueMap> jetIdMap;
+
+   std::ostringstream JetLabel, JetIdLabel;
+   JetLabel << "ak" << int(m_jetRadius*10) << "CastorJets";
+   JetIdLabel << "ak" << int(m_jetRadius*10) << "CastorJetID";
+
+   iEvent.getByLabel(JetLabel.str().c_str(), jetsIn);
+   iEvent.getByLabel(JetIdLabel.str().c_str(),jetIdMap);
+
+   // add jets to tree
+   for (edm::View<reco::BasicJet>::const_iterator ibegin = jetsIn->begin(), iend = jetsIn->end(), ijet = ibegin; ijet != iend; ++ijet) 
+   {
+       unsigned int idx = ijet - ibegin;
+ 	   const reco::BasicJet &basicjet = (*jetsIn)[idx];
+       edm::RefToBase<reco::BasicJet> jetRef = jetsIn->refAt(idx);
+       reco::CastorJetID const & jetId = (*jetIdMap)[jetRef];
+       if (basicjet.p4().energy()>=m_minCastorJetEnergy) {
+           addToP4Vec("P4",basicjet.p4());
+           addToIVec("nTowers", jetId.nTowers);
+           addToFVec("fem", jetId.fem);
+           addToFVec("width", jetId.width);
+           addToFVec("depth", jetId.depth);
+
+      }
+   }
+}

--- a/Core/src/CastorRecHitView.cc
+++ b/Core/src/CastorRecHitView.cc
@@ -1,0 +1,25 @@
+#include "CommonFSQFramework/Core/interface/CastorRecHitView.h"
+#include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+
+CastorRecHitView::CastorRecHitView(const edm::ParameterSet& iConfig, TTree * tree):
+EventViewBase(iConfig,  tree)
+{
+   registerVecFloat("Energy", tree);
+   registerVecInt("Sector", tree);
+   registerVecInt("Module", tree);
+}
+
+void CastorRecHitView::fillSpecific(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+   edm::Handle< edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> > > castorRecHits;
+   iEvent.getByLabel("castorreco",castorRecHits);  
+
+   // add rechits to tree
+    for (unsigned int iRecHit=0; iRecHit < castorRecHits->size(); ++iRecHit) {
+        CastorRecHit rh = (*castorRecHits)[iRecHit];
+        addToFVec("Energy", rh.energy());
+        addToIVec("Sector", rh.id().sector());
+        addToIVec("Module", rh.id().module());
+    }
+}


### PR DESCRIPTION
Added two MiniViews: CastorJets and CastorRecHits
Examples for use in skimming are in Core/python/CastorViewsConfigs.py
Core/src/BuildFile.xml and CFFTreeProducer.cc are updated to account for new MiniViews
