### PR TITLE
update Castor Views

### DIFF
--- a/Core/interface/CastorRecHitView.h
+++ b/Core/interface/CastorRecHitView.h
@@ -8,7 +8,9 @@ class CastorRecHitView: public EventViewBase {
        CastorRecHitView(const edm::ParameterSet& ps, TTree * tree);
 
     private:
-      virtual void fillSpecific(const edm::Event&, const edm::EventSetup&);  
+      virtual void fillSpecific(const edm::Event&, const edm::EventSetup&);
+      bool m_onlyGoodRecHits;
+      bool m_saturationInfo;
 };
 
 #endif

--- a/Core/python/CastorViewsConfigs.py
+++ b/Core/python/CastorViewsConfigs.py
@@ -2,13 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 def get(todo):
     defs = {}
-    defs["ak5GenJetView"]= cms.PSet(   
-        miniView = cms.string("GenJetView"),
-        branchPrefix = cms.untracked.string("ak5GenJets"),
-        maxEta = cms.double(7.0),
-        minPt = cms.double(1.0),
-        genJets = cms.InputTag("ak5GenJets"),
-    )
 
     defs["ak5CastorJetView"]= cms.PSet(   
         miniView = cms.string("CastorJetView"),
@@ -24,32 +17,19 @@ def get(todo):
         jetRadius = cms.double(0.7)
     )
 
-    defs["VerticesView"]= cms.PSet(   
-        miniView = cms.string("VerticesView"),
-        branchPrefix = cms.untracked.string("Vtx"),
-        src = cms.InputTag("offlinePrimaryVertices"),
-    )
-
-    defs["CastorRecHitView"]= cms.PSet(   
+    defs["CastorRecHitViewFull"]= cms.PSet(   
         miniView = cms.string("CastorRecHitView"),
         branchPrefix = cms.untracked.string("CastorRecHit"),
+        onlyGoodRecHits = cms.bool(False),
+        writeSaturationInfo = cms.bool(True),        
     )   
 
-    defs["JetViewPFAK4CHS"]  = cms.PSet(
-        miniView = cms.string("JetView"),
-        storeageVersion = cms.untracked.int32(0),
-        disableJetID = cms.bool(True),
-        optionalCaloJets4ID = cms.InputTag(""),#ak5CaloJets","","RECO"),
-        optionalCaloID4ID  = cms.InputTag(""),#ak5JetID"),
-        branchPrefix = cms.untracked.string("PFAK4CHS"),
-        maxEta = cms.double(5.2),
-        minPt = cms.double(1),
-        maxnum = cms.int32(3),
-        input = cms.InputTag("selectedPatJetsAK4PFCHSCopy"),
-        variations= cms.vstring(""),
-        jerFactors = cms.vstring(  # PF10
-                "5.5 1 0.007 0.07 0.072"),
-    )
+    defs["CastorRecHitViewBasic"]= cms.PSet(   
+        miniView = cms.string("CastorRecHitView"),
+        branchPrefix = cms.untracked.string("CastorRecHit"),
+        onlyGoodRecHits = cms.bool(True),
+        writeSaturationInfo = cms.bool(False),        
+    )   
 
     ret = {}
     for t in todo:

--- a/Core/src/BuildFile.xml
+++ b/Core/src/BuildFile.xml
@@ -9,6 +9,8 @@
 <use name="DataFormats/PatCandidates"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="CondFormats/JetMETObjects"/>
+<use name="CondFormats/CastorObjects"/>
+<use name="CondFormats/DataRecord"/>
 <use name="DataFormats/HcalRecHit"/>
 <export>
    <lib name="1"/>

--- a/Core/src/CastorJetView.cc
+++ b/Core/src/CastorJetView.cc
@@ -12,6 +12,8 @@ EventViewBase(iConfig,  tree)
     registerVecFloat("fem", tree);
     registerVecFloat("width", tree);
     registerVecFloat("depth", tree);
+    registerVecFloat("fhot", tree);
+    registerVecFloat("sigmaz", tree);
 
     // fetch config data
     m_minCastorJetEnergy = iConfig.getParameter<double>("minCastorJetEnergy");
@@ -45,6 +47,8 @@ void CastorJetView::fillSpecific(const edm::Event& iEvent, const edm::EventSetup
            addToFVec("fem", jetId.fem);
            addToFVec("width", jetId.width);
            addToFVec("depth", jetId.depth);
+           addToFVec("fhot", jetId.fhot);
+           addToFVec("sigmaz", jetId.sigmaz);
 
       }
    }

--- a/Core/src/CastorRecHitView.cc
+++ b/Core/src/CastorRecHitView.cc
@@ -1,6 +1,11 @@
 #include "CommonFSQFramework/Core/interface/CastorRecHitView.h"
 #include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "CondFormats/CastorObjects/interface/CastorChannelQuality.h"
+#include "CondFormats/CastorObjects/interface/CastorChannelStatus.h"
+#include "CondFormats/DataRecord/interface/CastorChannelQualityRcd.h"
 
 CastorRecHitView::CastorRecHitView(const edm::ParameterSet& iConfig, TTree * tree):
 EventViewBase(iConfig,  tree)
@@ -8,6 +13,7 @@ EventViewBase(iConfig,  tree)
    registerVecFloat("Energy", tree);
    registerVecInt("Sector", tree);
    registerVecInt("Module", tree);
+   registerVecInt("isBad", tree);
 }
 
 void CastorRecHitView::fillSpecific(const edm::Event& iEvent, const edm::EventSetup& iSetup){
@@ -15,11 +21,30 @@ void CastorRecHitView::fillSpecific(const edm::Event& iEvent, const edm::EventSe
    edm::Handle< edm::SortedCollection<CastorRecHit,edm::StrictWeakOrdering<CastorRecHit> > > castorRecHits;
    iEvent.getByLabel("castorreco",castorRecHits);  
 
+   // retrieve the channel quality lists from database
+   edm::ESHandle<CastorChannelQuality> p;
+   iSetup.get<CastorChannelQualityRcd>().get(p);
+   std::vector<DetId> channels = p->getAllChannels();
+
    // add rechits to tree
     for (unsigned int iRecHit=0; iRecHit < castorRecHits->size(); ++iRecHit) {
         CastorRecHit rh = (*castorRecHits)[iRecHit];
+        HcalCastorDetId castorid = rh.id();
+        DetId genericID=(DetId)castorid;
+
+        bool RechitIsBad = false;
+        for (std::vector<DetId>::iterator channel = channels.begin();channel != channels.end();channel++) {
+            if (channel->rawId() == genericID.rawId()) {
+                // if the rechit is found in the list, mark it bad
+                RechitIsBad=true;
+                break;
+                }
+        }
+
         addToFVec("Energy", rh.energy());
-        addToIVec("Sector", rh.id().sector());
-        addToIVec("Module", rh.id().module());
+        addToIVec("Sector", castorid.sector());
+        addToIVec("Module", castorid.module());
+        addToIVec("isBad", (int)RechitIsBad);
+
     }
 }


### PR DESCRIPTION
I added the requested JetID information and the RecHit channel quality flag;
Additionally I added rechit saturation and desaturation flags;
The CastorViewsConfig has been updated accordingly, now providing
-> CastorRecHitFull (including all RecHits, BadChannel, saturation, and desaturation flag)
-> CastorRecHitBasic (including only good RecHits, no additional information)
These configs can of course be modified.
