### PR TITLE
needed additional consume command in TriggerResultsView

### DIFF
--- a/Core/src/TriggerResultsView.cc
+++ b/Core/src/TriggerResultsView.cc
@@ -72,6 +72,7 @@ EventViewBase(iConfig,  tree), hltprovider_(iConfig, iC, *module)
 
     // register consumes
     iC.consumes<L1GlobalTriggerReadoutRecord>(edm::InputTag("gtDigis"));
+    iC.consumes<edm::TriggerResults>(edm::InputTag("TriggerResults","","HLT"));
 }
 
 void TriggerResultsView::doBeginRun(const edm::Run& r, const edm::EventSetup& es) {


### PR DESCRIPTION
@sebaur

for the InputTag I needed also to define the process "HLT". I hope that is always the case also in standard RECO files. The point is I tested it by RECO data produce from Sebastian where the process name for all collections are "HLT".
